### PR TITLE
Update GraalVM workflow with new command option

### DIFF
--- a/.github/workflows/build-with-bal-test-native.yml
+++ b/.github/workflows/build-with-bal-test-native.yml
@@ -33,7 +33,7 @@ jobs:
 
             - name: Run Ballerina tests using the native executable
               working-directory: ./excel
-              run: bal test --native
+              run: bal test --graalvm
               env:
                 JAVA_HOME: /usr/lib/jvm/default-jvm
                 REFRESH_URL: ${{ secrets.REFRESH_URL }}


### PR DESCRIPTION
This PR will rename the command option in the graalVM workflow from --native to --graalvm. Fixes https://github.com/ballerina-platform/ballerina-extended-library/issues/531